### PR TITLE
Fix Segmentation Fault in solve_pcg.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,45 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# build folder
+build*
+
+# vscode config
+.vscode
+
+# emacs desktop config
+.emacs.desktop.lock
+.emacs.desktop
+
+# private files
+_*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 2.6)
+project(cuda_pcg)
+
+find_package(CUDA REQUIRED)
+if (CUDA_FOUND)
+  message(STATUS "CUDA_INCLUDE_DIRS: ${CUDA_INCLUDE_DIRS}")
+  message(STATUS "CUDA_VERSION     : ${CUDA_VERSION_STRING}")
+  include_directories(${CUDA_INCLUDE_DIRS})
+endif (CUDA_FOUND)
+
+include_directories(Cuda)
+
+file(GLOB cuda_pcg_header Cuda/*.cuh)
+file(GLOB cuda_pcg_source Cuda/*.cu)
+
+CUDA_ADD_EXECUTABLE(cuda_pcg ${cuda_pcg_header} ${cuda_pcg_source})
+target_link_libraries(cuda_pcg
+  ${CUDA_cusparse_LIBRARY}
+  ${CUDA_cublas_LIBRARY}
+  )

--- a/Cuda/Kernel_Energy.cuh
+++ b/Cuda/Kernel_Energy.cuh
@@ -116,7 +116,7 @@ namespace Kernel_Energy {
 			cudaThreadSynchronize();
 		}
 
-		void calc_hes(int hes_cal_index_size = 0) {		//传入生成矩阵的kernel的size大小
+		void calc_hes(int hes_cal_index_size = 0) {		//浼犲叆鐢熸垚鐭╅樀鐨刱ernel鐨剆ize澶у皬
 			if (hes_cal_index_size == 0) hes_cal_index_size = size;
 			hes << <32 * numSMs, 256 >> > (dev_x, dev_pos, dev_hes_val, hes_cal_index_size);
 			cudaThreadSynchronize();

--- a/Cuda/kernel.cu
+++ b/Cuda/kernel.cu
@@ -141,7 +141,7 @@ __global__ void calculate_pos(double* devx, thrust::pair<int, int>* pos, double*
 //		cudaThreadSynchronize();
 //	}
 //
-//	void calc_hes(int hes_cal_index_size=0) {		//传入生成矩阵的kernel的size大小
+//	void calc_hes(int hes_cal_index_size=0) {		//浼犲叆鐢熸垚鐭╅樀鐨刱ernel鐨剆ize澶у皬
 //		if (hes_cal_index_size == 0) hes_cal_index_size = size;
 //		calculate_pos<< <32 * numSMs, 256 >> > (dev_x, dev_pos, dev_hes_val, hes_cal_index_size);
 //		cudaThreadSynchronize();

--- a/Cuda/pcg.cuh
+++ b/Cuda/pcg.cuh
@@ -213,6 +213,7 @@ void PCG::initialize(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* 
 		std::cout << "CUBLAS对象实例化出错" << std::endl;
 		getchar();
 	}
+	cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
 }
 
 PCG::PCG(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp 最后一项必须为总非零点数目

--- a/Cuda/pcg.cuh
+++ b/Cuda/pcg.cuh
@@ -169,7 +169,7 @@ PCG::PCG(int Ntemp, int NNZtemp, thrust::pair<int, int>* coo, double* hes_val, d
 	initialize(Ntemp, NNZtemp, hes_val, right_hand, csr, pos_y, TYPE);
 }
 
-void PCG::initialize(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp ×îºóÒ»Ïî±ØĞëÎª×Ü·ÇÁãµãÊıÄ¿
+void PCG::initialize(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp æœ€åä¸€é¡¹å¿…é¡»ä¸ºæ€»éé›¶ç‚¹æ•°ç›®
 	readIAandJA(Ntemp, NNZtemp, IAtemp, JAtemp, TYPE);
 	N = Ntemp;
 	NNZ = NNZtemp;
@@ -210,16 +210,16 @@ void PCG::initialize(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* 
 	status = cublasCreate(&handle);
 	if (status != CUBLAS_STATUS_SUCCESS)
 	{
-		std::cout << "CUBLAS¶ÔÏóÊµÀı»¯³ö´í" << std::endl;
+		std::cout << "CUBLASå¯¹è±¡å®ä¾‹åŒ–å‡ºé”™" << std::endl;
 		getchar();
 	}
 }
 
-PCG::PCG(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp ×îºóÒ»Ïî±ØĞëÎª×Ü·ÇÁãµãÊıÄ¿
+PCG::PCG(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp æœ€åä¸€é¡¹å¿…é¡»ä¸ºæ€»éé›¶ç‚¹æ•°ç›®
 	initialize(Ntemp, NNZtemp, Atemp, Btemp, IAtemp, JAtemp, TYPE);
 }
 
-//PCG::PCG(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp ×îºóÒ»Ïî±ØĞëÎª×Ü·ÇÁãµãÊıÄ¿
+//PCG::PCG(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int* JAtemp, constuctor_type TYPE) { //IAtemp æœ€åä¸€é¡¹å¿…é¡»ä¸ºæ€»éé›¶ç‚¹æ•°ç›®
 //	readIAandJA(Ntemp, NNZtemp, IAtemp, JAtemp, TYPE);
 //	N = Ntemp;
 //	NNZ = NNZtemp;
@@ -260,7 +260,7 @@ PCG::PCG(int Ntemp, int NNZtemp, double* Atemp, double* Btemp, int* IAtemp, int*
 //	status = cublasCreate(&handle);
 //	if (status != CUBLAS_STATUS_SUCCESS)
 //	{
-//		std::cout << "CUBLAS¶ÔÏóÊµÀı»¯³ö´í" << std::endl;
+//		std::cout << "CUBLASå¯¹è±¡å®ä¾‹åŒ–å‡ºé”™" << std::endl;
 //		getchar();
 //	}
 //}
@@ -300,7 +300,7 @@ void PCG::update_hes(double* Atemp, double* Btemp, constuctor_type TYPE) {
 	status = cublasCreate(&handle);
 	if (status != CUBLAS_STATUS_SUCCESS)
 	{
-		std::cout << "CUBLAS¶ÔÏóÊµÀı»¯³ö´í" << std::endl;
+		std::cout << "CUBLASå¯¹è±¡å®ä¾‹åŒ–å‡ºé”™" << std::endl;
 		getchar();
 	}
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+
+if [ $# -eq 0 ]; then
+        folder="build/debug"
+        flag="-DCMAKE_BUILD_TYPE=Debug"
+elif [ $# -eq 1 ] && [ $1 == "release" ]; then
+        folder="build/release"
+        flag="-DCMAKE_BUILD_TYPE=Release"
+else
+        echo "unvalid arguments"
+        exit 1
+fi
+
+cmake . -B$folder $flag -DCMAKE_C_COMPILER=/usr/bin/gcc-6
+if [ $? -ne 0 ]; then
+        echo "cmake failed."
+        exit 1
+fi
+cd $folder
+make
+if [ $? -ne 0 ]; then
+        echo "make failed."
+        exit 1
+fi


### PR DESCRIPTION
我在初始化的时候，对cublas的handle加了一句：

```c++
cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
```

现在不见有Segmentation Fault了。

具体原因可能还要你再看看，大概可能就是device指针和host指针的问题。

